### PR TITLE
Fixed routing for Laravel 5.3.

### DIFF
--- a/src/Auth/Console/MakeVerifyEmailsCommand.php
+++ b/src/Auth/Console/MakeVerifyEmailsCommand.php
@@ -48,7 +48,7 @@ class MakeVerifyEmailsCommand extends Command
         $this->info('Updated routes file.');
 
         file_put_contents(
-            app_path('Http/routes.php'),
+            base_path('routes/web.php'),
             file_get_contents(__DIR__.'/stubs/make/routes.stub'),
             FILE_APPEND
         );


### PR DESCRIPTION
In Laravel 5.3 _app/Http/routes.php_ was moved to _routes/web.php_.